### PR TITLE
加上丢失的左括号

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 
 ### 程序员黑名单
-* [如何看待摩拜前端负责人小春张耀春)疑似性骚扰女下属？](https://www.zhihu.com/question/289146339?from=groupmessage&isappinstalled=0&utm_medium=social&utm_oi=581028265741783040&utm_source=wechat_session)
+* [如何看待摩拜前端负责人小春（张耀春）疑似性骚扰女下属？](https://www.zhihu.com/question/289146339?from=groupmessage&isappinstalled=0&utm_medium=social&utm_oi=581028265741783040&utm_source=wechat_session)
 
 ### 普通程序员
 


### PR DESCRIPTION
在程序员黑名单那里的“案例”补充那个丢失的左括号